### PR TITLE
proxy and backend connecition support both single & multi connections

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -17,6 +17,10 @@ password=
 
 ##### Properties below are only for proxies
 
+# Proxy connections number model with backend server: server/slot, server means only one connection between proxy and backend server, 
+# slot means every slot has one connection between proxy and backend server, default is server
+backend_connection_model=server
+
 # Proxy will ping-pong backend redis periodly to keep-alive
 backend_ping_period=5
 

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	proto         string //tcp or tcp4
 	provider      string
 	dashboardAddr string
+	connModel     string //server or slot
 
 	pingPeriod       int // seconds
 	maxTimeout       int // seconds
@@ -56,6 +57,9 @@ func LoadConf(configFile string) (*Config, error) {
 
 	conf.proto, _ = c.ReadString("proto", "tcp")
 	conf.provider, _ = c.ReadString("coordinator", "zookeeper")
+
+    	conf.connModel, _ = c.ReadString("backend_connection_model", "server")
+   	conf.connModel = strings.TrimSpace(conf.connModel)
 
 	loadConfInt := func(entry string, defval int) int {
 		v, _ := c.ReadInt(entry, defval)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -74,7 +74,7 @@ func New(addr string, debugVarAddr string, conf *Config) *Server {
 	} else {
 		s.listener = l
 	}
-	s.router = router.NewWithAuth(conf.passwd)
+	s.router = router.NewWithAuth(conf.passwd, conf.connModel)
 	s.evtbus = make(chan interface{}, 1024)
 
 	s.register()


### PR DESCRIPTION
As we know, codis proxy and backend server(redis) use one connection, this works well on fast redis, however if we want to use some disk nosql database which is not that fast(eg ssdb or pika)  as backend server, the performance descend a lot.
Disk database could store more data than memory database, it is used a lot in many companies.
This PR support codis 2.0 could be configured both multi and single connection between proxy and backend server.
