### PR TITLE
codis 3.2 支持运行在 kubernetes环境

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 export GO15VENDOREXPERIMENT=1
 
-build-all: codis-server codis-dashboard codis-proxy codis-admin codis-fe clean-gotest
+build-all: codis-server codis-dashboard codis-proxy codis-admin codis-ha codis-fe clean-gotest
 
 codis-deps:
 	@mkdir -p bin config && bash version
@@ -18,6 +18,9 @@ codis-proxy: codis-deps
 
 codis-admin: codis-deps
 	go build -i -o bin/codis-admin ./cmd/admin
+
+codis-ha: codis-deps
+	go build -i -o bin/codis-ha ./cmd/ha
 
 codis-fe: codis-deps
 	go build -i -o bin/codis-fe ./cmd/fe

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -25,7 +25,7 @@ import (
 func main() {
 	const usage = `
 Usage:
-	codis-dashboard [--ncpu=N] [--config=CONF] [--log=FILE] [--log-level=LEVEL] [--host-admin=ADDR] [--pidfile=FILE]
+	codis-dashboard [--ncpu=N] [--config=CONF] [--log=FILE] [--log-level=LEVEL] [--host-admin=ADDR] [--zookeeper=ADDR|--etcd=ADDR|--filesystem=ROOT] [--product_name=NAME] [--product_auth=AUTH] [--pidfile=FILE] [--remove-lock]
 	codis-dashboard  --default-config
 	codis-dashboard  --version
 
@@ -88,11 +88,44 @@ Options:
 		log.Warnf("option --host-admin = %s", s)
 	}
 
+	switch {
+	case d["--zookeeper"] != nil:
+		config.CoordinatorName = "zookeeper"
+		config.CoordinatorAddr = utils.ArgumentMust(d, "--zookeeper")
+	case d["--etcd"] != nil:
+		config.CoordinatorName = "etcd"
+		config.CoordinatorAddr = utils.ArgumentMust(d, "--etcd")
+	case d["--filesystem"] != nil:
+		config.CoordinatorName = "filesystem"
+		config.CoordinatorAddr = utils.ArgumentMust(d, "--filesystem")
+	}
+
+	if s, ok := utils.Argument(d, "--product_name"); ok {
+		config.ProductName = s
+		log.Warnf("option --product_nam = %s", s)
+	}
+	if s, ok := utils.Argument(d, "--product_auth"); ok {
+		config.ProductAuth = s
+		log.Warnf("option --product_auth = %s", s)
+	}
+
 	client, err := models.NewClient(config.CoordinatorName, config.CoordinatorAddr, time.Minute)
 	if err != nil {
 		log.PanicErrorf(err, "create '%s' client to '%s' failed", config.CoordinatorName, config.CoordinatorAddr)
 	}
 	defer client.Close()
+
+	if d["--remove-lock"].(bool) {
+		store := models.NewStore(client, config.ProductName)
+		defer store.Close()
+
+		log.Warnf("force remove-lock")
+		if err := store.Release(); err != nil {
+			log.WarnErrorf(err, "force remove-lock failed")
+		} else {
+			log.Warnf("force remove-lock OK")
+		}
+	}
 
 	s, err := topom.New(client, config)
 	if err != nil {

--- a/cmd/ha/main.go
+++ b/cmd/ha/main.go
@@ -20,7 +20,7 @@ import (
 func main() {
 	const usage = `
 Usage:
-	codis-ha [--log=FILE] [--log-level=LEVEL] [--interval=SECONDS] --dashboard=ADDR
+	codis-ha [--log=FILE] [--log-level=LEVEL] [--interval=SECONDS] --dashboard=ADDR [--no-maintains]
 	codis-ha  --version
 
 Options:
@@ -66,6 +66,11 @@ Options:
 	log.Warnf("set dashboard = %s", dashboard)
 	log.Warnf("set interval = %d (seconds)", interval)
 
+	var noMaintains = false
+	if d["--no-maintains"].(bool) {
+		noMaintains = true
+	}
+
 	client := topom.NewApiClient(dashboard)
 
 	t, err := client.Model()
@@ -86,7 +91,9 @@ Options:
 		hc := newHealthyChecker(client)
 		hc.LogProxyStats()
 		hc.LogGroupStats()
-		hc.Maintains(client, interval*10, prodcutAuth)
+		if !noMaintains {
+			hc.Maintains(client, interval*10, prodcutAuth)
+		}
 
 		time.Sleep(time.Second * time.Duration(interval))
 	}

--- a/cmd/ha/main.go
+++ b/cmd/ha/main.go
@@ -1,0 +1,362 @@
+// Copyright 2016 CodisLabs. All Rights Reserved.
+// Licensed under the MIT (MIT-LICENSE.txt) license.
+
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/docopt/docopt-go"
+
+	"github.com/CodisLabs/codis/pkg/topom"
+	"github.com/CodisLabs/codis/pkg/utils"
+	"github.com/CodisLabs/codis/pkg/utils/log"
+	"github.com/CodisLabs/codis/pkg/utils/math2"
+	"github.com/CodisLabs/codis/pkg/utils/redis"
+)
+
+func main() {
+	const usage = `
+Usage:
+	codis-ha [--log=FILE] [--log-level=LEVEL] [--interval=SECONDS] --dashboard=ADDR
+	codis-ha  --version
+
+Options:
+	-l FILE, --log=FILE         set path/name of daliy rotated log file.
+	--log-level=LEVEL           set the log-level, should be INFO,WARN,DEBUG or ERROR, default is INFO.
+`
+	d, err := docopt.Parse(usage, nil, true, "", false)
+	if err != nil {
+		log.PanicError(err, "parse arguments failed")
+	}
+
+	if d["--version"].(bool) {
+		fmt.Println("version:", utils.Version)
+		fmt.Println("compile:", utils.Compile)
+		return
+	}
+
+	if s, ok := utils.Argument(d, "--log"); ok {
+		w, err := log.NewRollingFile(s, log.DailyRolling)
+		if err != nil {
+			log.PanicErrorf(err, "open log file %s failed", s)
+		} else {
+			log.StdLog = log.New(w, "")
+		}
+	}
+	log.SetLevel(log.LevelInfo)
+
+	if s, ok := utils.Argument(d, "--log-level"); ok {
+		if !log.SetLevelString(s) {
+			log.Panicf("option --log-level = %s", s)
+		}
+	}
+
+	var interval = 5
+	if n, ok := utils.ArgumentInteger(d, "--interval"); ok {
+		if n <= 0 {
+			log.Panicf("option --interval = %d", n)
+		}
+		interval = n
+	}
+
+	dashboard := utils.ArgumentMust(d, "--dashboard")
+	log.Warnf("set dashboard = %s", dashboard)
+	log.Warnf("set interval = %d (seconds)", interval)
+
+	client := topom.NewApiClient(dashboard)
+
+	t, err := client.Model()
+	if err != nil {
+		log.PanicErrorf(err, "rpc fetch model failed")
+	}
+	log.Warnf("topom =\n%s", t.Encode())
+
+	client.SetXAuth(t.ProductName)
+
+	overview, err := client.Overview()
+	if err != nil {
+		log.PanicErrorf(err, "rpc fetch overview failed")
+	}
+	prodcutAuth := overview.Config.ProductAuth
+
+	for {
+		hc := newHealthyChecker(client)
+		hc.LogProxyStats()
+		hc.LogGroupStats()
+		hc.Maintains(client, interval*10, prodcutAuth)
+
+		time.Sleep(time.Second * time.Duration(interval))
+	}
+}
+
+const (
+	CodeAlive = iota + 100
+	CodeError
+	CodeMissing
+	CodeTimeout
+)
+
+const (
+	CodeSyncReady = iota + 200
+	CodeSyncError
+	CodeSyncBroken
+)
+
+type HealthyChecker struct {
+	*topom.Stats
+	pstatus map[string]int
+	sstatus map[string]int
+}
+
+func newHealthyChecker(client *topom.ApiClient) *HealthyChecker {
+	stats, err := client.Stats()
+	if err != nil {
+		log.PanicErrorf(err, "rpc stats failed")
+	}
+
+	hc := &HealthyChecker{Stats: stats}
+
+	hc.pstatus = make(map[string]int)
+	for _, p := range hc.Proxy.Models {
+		switch stats := hc.Proxy.Stats[p.Token]; {
+		case stats == nil:
+			hc.pstatus[p.Token] = CodeMissing
+		case stats.Error != nil:
+			hc.pstatus[p.Token] = CodeError
+		case stats.Timeout || stats.Stats == nil:
+			hc.pstatus[p.Token] = CodeTimeout
+		default:
+			hc.pstatus[p.Token] = CodeAlive
+		}
+	}
+
+	hc.sstatus = make(map[string]int)
+	for _, g := range hc.Group.Models {
+		for i, x := range g.Servers {
+			var addr = x.Addr
+			switch stats := hc.Group.Stats[addr]; {
+			case stats == nil:
+				hc.sstatus[addr] = CodeMissing
+			case stats.Error != nil:
+				hc.sstatus[addr] = CodeError
+			case stats.Timeout || stats.Stats == nil:
+				hc.sstatus[addr] = CodeTimeout
+			default:
+				if i == 0 {
+					if stats.Stats["master_addr"] != "" {
+						hc.sstatus[addr] = CodeSyncError
+					} else {
+						hc.sstatus[addr] = CodeSyncReady
+					}
+				} else {
+					if stats.Stats["master_addr"] != g.Servers[0].Addr {
+						hc.sstatus[addr] = CodeSyncError
+					} else {
+						switch stats.Stats["master_link_status"] {
+						default:
+							hc.sstatus[addr] = CodeSyncError
+						case "up":
+							hc.sstatus[addr] = CodeSyncReady
+						case "down":
+							hc.sstatus[addr] = CodeSyncBroken
+						}
+					}
+				}
+			}
+		}
+	}
+	return hc
+}
+
+func (hc *HealthyChecker) LogProxyStats() {
+	var format string
+	var wpid int
+	for _, p := range hc.Proxy.Models {
+		wpid = math2.MaxInt(wpid, len(strconv.Itoa(p.Id)))
+	}
+	format += fmt.Sprintf("proxy-%%0%dd [T] %%s", wpid)
+
+	var waddr1, waddr2 int
+	for _, p := range hc.Proxy.Models {
+		waddr1 = math2.MaxInt(waddr1, len(p.AdminAddr))
+		waddr2 = math2.MaxInt(waddr2, len(p.ProxyAddr))
+	}
+	format += fmt.Sprintf(" [A] %%-%ds", waddr1)
+	format += fmt.Sprintf(" [P] %%-%ds", waddr2)
+
+	for _, p := range hc.Proxy.Models {
+		switch hc.pstatus[p.Token] {
+		case CodeMissing:
+			log.Warnf("[?] "+format, p.Id, p.Token, p.AdminAddr, p.ProxyAddr)
+		case CodeError:
+			log.Warnf("[E] "+format, p.Id, p.Token, p.AdminAddr, p.ProxyAddr)
+		case CodeTimeout:
+			log.Warnf("[T] "+format, p.Id, p.Token, p.AdminAddr, p.ProxyAddr)
+		default:
+			log.Infof("[ ] "+format, p.Id, p.Token, p.AdminAddr, p.ProxyAddr)
+		}
+	}
+}
+
+func (hc *HealthyChecker) LogGroupStats() {
+	var format string
+	var wgid, widx int
+	for _, g := range hc.Group.Models {
+		wgid = math2.MaxInt(wgid, len(strconv.Itoa(g.Id)))
+		for i, _ := range g.Servers {
+			widx = math2.MaxInt(widx, len(strconv.Itoa(i)))
+		}
+	}
+	format += fmt.Sprintf("group-%%0%dd [%%0%dd]", wgid, widx)
+
+	var waddr int
+	for _, g := range hc.Group.Models {
+		for _, x := range g.Servers {
+			waddr = math2.MaxInt(waddr, len(x.Addr))
+		}
+	}
+	format += fmt.Sprintf(" %%-%ds", waddr)
+
+	for _, g := range hc.Group.Models {
+		for i, x := range g.Servers {
+			switch hc.sstatus[x.Addr] {
+			case CodeMissing:
+				log.Warnf("[?] "+format, g.Id, i, x.Addr)
+			case CodeError:
+				log.Warnf("[E] "+format, g.Id, i, x.Addr)
+			case CodeTimeout:
+				log.Warnf("[T] "+format, g.Id, i, x.Addr)
+			case CodeSyncReady:
+				log.Infof("[ ] "+format, g.Id, i, x.Addr)
+			case CodeSyncError, CodeSyncBroken:
+				log.Warnf("[X] "+format, g.Id, i, x.Addr)
+			}
+		}
+	}
+}
+
+func (hc *HealthyChecker) Maintains(client *topom.ApiClient, maxdown int, auth string) {
+	// remove proxy at state error from codis
+	for _, p := range hc.Proxy.Models {
+		switch hc.pstatus[p.Token] {
+		case CodeError, CodeTimeout, CodeMissing:
+			log.Warnf("try to remove proxy-[%s]", p.AdminAddr)
+			if err := client.RemoveProxy(p.Token, true); err != nil {
+				log.ErrorErrorf(err, "call rpc remove-proxy to dashboard %s failed", p.AdminAddr)
+				return
+			}
+			log.Warnf("try to remove proxy done.")
+			return
+		default:
+			continue
+		}
+	}
+
+	// remove server at state error from codis
+Groups:
+	for _, g := range hc.Group.Models {
+		for i, x := range g.Servers {
+			// if master state is not right, promote slave to master first(if have slave)
+			if i == 0 {
+				if len(g.Servers) > 1 {
+					switch hc.sstatus[g.Servers[0].Addr] {
+					case CodeError, CodeMissing, CodeTimeout, CodeSyncError:
+						log.Warnf("codis-server (master) %s state error", x.Addr)
+						break Groups
+					default:
+						continue
+					}
+				} else {
+					continue
+				}
+			}
+			// remove codis server(slave and only one master) which state is not right
+			switch hc.sstatus[x.Addr] {
+			case CodeError, CodeMissing, CodeTimeout, CodeSyncError:
+				log.Warnf("try to group-del-server to dashboard %s", x.Addr)
+				if err := client.GroupDelServer(g.Id, x.Addr); err != nil {
+					log.ErrorErrorf(err, "call rpc group-del-server to dashboard %s failed", x.Addr)
+					return
+				}
+				log.Debugf("call rpc group-del-server OK")
+
+				// trt to shutdown codis-server as slave in error state
+				log.Warnf("try to shutdown codis-server(slave) %s", x.Addr)
+				c, err := redis.NewClient(x.Addr, auth, time.Minute*30)
+				if err != nil {
+					log.WarnErrorf(err, "connect to codis-server(slave) %s failed", x.Addr)
+					return
+				}
+				defer c.Close()
+				if err := c.Shutdown(); err != nil {
+					log.WarnErrorf(err, "try to shutdown codis-server %s failed", x.Addr)
+					return
+				}
+				return
+			case CodeSyncBroken:
+				log.Warnf("slave %s master link down", x.Addr)
+			default:
+				continue
+			}
+		}
+	}
+
+	// promote group server
+	for _, g := range hc.Group.Models {
+		if len(g.Servers) != 0 {
+			switch hc.sstatus[g.Servers[0].Addr] {
+			case CodeMissing, CodeError, CodeTimeout:
+				var synced int
+				var picked, picked2 = 0, 0
+				var mindown, mindown2 = maxdown + 1, 65535
+				for i := 1; i < len(g.Servers); i++ {
+					var addr = g.Servers[i].Addr
+					switch hc.sstatus[addr] {
+					case CodeSyncReady:
+						synced++
+					case CodeSyncBroken:
+						if stats := hc.Group.Stats[addr]; stats != nil && stats.Stats != nil {
+							n, err := strconv.Atoi(stats.Stats["master_link_down_since_seconds"])
+							if err != nil {
+								log.WarnErrorf(err, "try to get %s master_link_down_since_seconds failed", addr)
+								continue
+							}
+							if n >= 0 && n < mindown {
+								picked, mindown = i, n
+							}
+							if picked == 0 && n >= 0 && n < mindown2 {
+								picked2, mindown2 = i, n
+							}
+						}
+					case CodeSyncError:
+						if picked == 0 && picked2 == 0 {
+							picked2 = i
+						}
+					}
+				}
+				switch {
+				case picked == 0 && picked2 == 0:
+					log.Warnf("try to promote group-[%d], but synced = %d & picked = %d & picked2 = %d, giveup", g.Id, synced, picked, picked2)
+				case g.Promoting.State != "":
+					log.Warnf("try to promote group-[%d], but group is promoting = %s, please fix it manually", g.Id, g.Promoting.State)
+				case picked > 0 || picked2 > 0:
+					var pick int
+					if picked > 0 {
+						pick = picked
+					} else {
+						pick = picked2
+					}
+					var slave = g.Servers[pick].Addr
+					log.Warnf("try to promote group-[%d] with slave %s", g.Id, slave)
+					if err := client.GroupPromoteServer(g.Id, slave); err != nil {
+						log.ErrorErrorf(err, "rpc promote server failed")
+					}
+					log.Warnf("done.")
+				}
+			}
+		}
+	}
+}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -31,7 +31,7 @@ import (
 func main() {
 	const usage = `
 Usage:
-	codis-proxy [--ncpu=N [--max-ncpu=MAX]] [--config=CONF] [--log=FILE] [--log-level=LEVEL] [--host-admin=ADDR] [--host-proxy=ADDR] [--dashboard=ADDR|--zookeeper=ADDR|--etcd=ADDR|--filesystem=ROOT|--fillslots=FILE] [--ulimit=NLIMIT] [--pidfile=FILE]
+	codis-proxy [--ncpu=N [--max-ncpu=MAX]] [--config=CONF] [--log=FILE] [--log-level=LEVEL] [--host-admin=ADDR] [--host-proxy=ADDR] [--dashboard=ADDR|--zookeeper=ADDR|--etcd=ADDR|--filesystem=ROOT|--fillslots=FILE] [--ulimit=NLIMIT] [--product_name=NAME] [--product_auth=AUTH] [--pidfile=FILE]
 	codis-proxy  --default-config
 	codis-proxy  --version
 
@@ -162,6 +162,15 @@ Options:
 		if err := json.Unmarshal(b, &slots); err != nil {
 			log.PanicErrorf(err, "decode slots from json failed")
 		}
+	}
+
+	if s, ok := utils.Argument(d, "--product_name"); ok {
+		config.ProductName = s
+		log.Warnf("option --product_nam = %s", s)
+	}
+	if s, ok := utils.Argument(d, "--product_auth"); ok {
+		config.ProductAuth = s
+		log.Warnf("option --product_auth = %s", s)
 	}
 
 	s, err := proxy.New(config)

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,25 @@
+## Usage
+
+### Build one codis cluster (codis master server has one slave)
+
+```
+$ sh start.sh buildup
+```
+
+### Clean up the codis cluster
+
+```
+$ sh start.sh cleanup
+```
+
+### Scale codis cluster proxy
+
+```
+$ sh start.sh scale-proxy $(number)
+```
+
+### Scale codis cluster server
+
+```
+$ sh start.sh scale-server $(number)
+```

--- a/kubernetes/codis-dashboard.yaml
+++ b/kubernetes/codis-dashboard.yaml
@@ -1,0 +1,54 @@
+apiVersion: "apps/v1beta1"
+kind: StatefulSet
+metadata:
+  name: codis-dashboard
+spec:
+  replicas: 1
+  serviceName: codis-dashboard
+  template:
+    metadata:
+      labels:
+        app: codis-dashboard
+    spec:
+      imagePullSecrets:
+      - name: your-registry
+      containers:
+      - name: codis-dashboard
+        image: codis-image
+        imagePullPolicy: IfNotPresent
+        command: ["codis-dashboard"]
+        args: ["-l","log/$(POD_NAME).log","-c","$(CODIS_PATH)/config/dashboard.toml","--host-admin","$(POD_IP):18080", "--zookeeper","$(ZK_ADDR)","--product_name","$(PRODUCT_NAME)","--pidfile","log/dashboard.pid","--remove-lock"]
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "-c", "codis-admin --dashboard-list  --zookeeper=${ZK_ADDR}"]
+          preStop:
+            exec:
+              command: [/bin/sh", "-c", "PID=$(cat log/dashboard.pid) && kill $PID && while ps -p 1 > /dev/null; do sleep 1; done"]
+        env:
+        - name: CODIS_PATH
+          value: "/gopath/src/github.com/CodisLabs/codis"
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ZK_ADDR
+          value: "zookeeper:2181"
+        - name: PRODUCT_NAME
+          value: "codis-test"
+        #- name: PRODUCT_AUTH
+        #  value: ""
+        ports:
+        - containerPort: 18080
+          name: dashboard
+        resources:
+          limits:
+            cpu: "4"
+            memory: 4Gi
+          requests:
+            cpu: "0.1"
+            memory: 0.1Gi

--- a/kubernetes/codis-fe.yaml
+++ b/kubernetes/codis-fe.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: codis-fe
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: codis-fe
+    spec:
+      imagePullSecrets:
+      - name: your-registry
+      containers:
+      - name: codis-fe
+        image: codis-image
+        imagePullPolicy: IfNotPresent
+        command: ["codis-fe"]
+        args: ["-l","log/$(POD_NAME).log","--zookeeper","$(ZK_ADDR)","--listen=$(POD_IP):8080","--assets=$(CODIS_PATH)/bin/assets"]
+        env:
+        - name: CODIS_PATH
+          value: "/gopath/src/github.com/CodisLabs/codis"
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ZK_ADDR
+          value: "zookeeper:2181"
+        ports:
+        - containerPort: 8080
+          name: fe
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: "0.1"
+            memory: 0.1Gi

--- a/kubernetes/codis-ha.yaml
+++ b/kubernetes/codis-ha.yaml
@@ -1,0 +1,50 @@
+apiVersion: "apps/v1beta1"
+kind: StatefulSet
+metadata:
+  name: codis-ha
+spec:
+  replicas: 1
+  serviceName: codis-ha
+  template:
+    metadata:
+      labels:
+        app: codis-ha
+      annotations:
+        scheduler.alpha.kubernetes.io/affinity: >
+            {
+              "podAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": [{
+                  "labelSelector": {
+                    "matchExpressions": [{
+                      "key": "app",
+                      "operator": "In",
+                      "values": ["codis-dashboard"]
+                    }]
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }]
+              }
+            }
+    spec:
+      imagePullSecrets:
+      - name: your-registry
+      containers:
+      - name: codis-ha
+        image: codis-image
+        imagePullPolicy: IfNotPresent
+        command: ["codis-ha"]
+        args: ["-l","log/$(POD_NAME).log","--interval","5","--dashboard=$(DASHBOARD_ADDR)"]
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DASHBOARD_ADDR
+          value: "codis-dashboard:18080"
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: "0.1"
+            memory: 0.1Gi

--- a/kubernetes/codis-proxy.yaml
+++ b/kubernetes/codis-proxy.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: codis-proxy
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: codis-proxy
+    spec:
+      imagePullSecrets:
+      - name: your-registry
+      containers:
+      - name: codis-proxy
+        image: codis-image
+        imagePullPolicy: IfNotPresent
+        command: ["codis-proxy"]
+        args: ["-l","log/$(POD_NAME).log","-c","$(CODIS_PATH)/config/proxy.toml","--host-admin","$(POD_IP):11080","--host-proxy","$(POD_IP):19000","--zookeeper","$(ZK_ADDR)","--product_name","$(PRODUCT_NAME)","--pidfile","log/proxy.pid"]
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "codis-admin --dashboard=${DASHBOARD_ADDR} --remove-proxy --addr=${POD_IP}:11080 1>/dev/null 2>&1"]
+        env:
+        - name: CODIS_PATH
+          value: "/gopath/src/github.com/CodisLabs/codis"
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ZK_ADDR
+          value: "zookeeper:2181"
+        - name: DASHBOARD_ADDR
+          value: "codis-dashboard:18080"
+        - name: PRODUCT_NAME
+          value: "codis-test"
+        #- name: PRODUCT_AUTH
+        #  value: ""
+        ports:
+        - containerPort: 11080
+          name: proxy
+        - containerPort: 19000
+          name: admin
+        resources:
+          limits:
+            cpu: "4"
+            memory: 4Gi
+          requests:
+            cpu: "0.1"
+            memory: 0.1Gi

--- a/kubernetes/codis-server.yaml
+++ b/kubernetes/codis-server.yaml
@@ -34,7 +34,7 @@ spec:
         image: codis-image
         imagePullPolicy: IfNotPresent
         command: ["codis-server"]
-        args: ["$(CODIS_PATH)/config/redis.conf","--logfile","$(POD_NAME).log","--protected-mode", "no", "--save", "", "--bind", "$(POD_IP)", "--daemonize", "no"]
+        args: ["$(CODIS_PATH)/config/redis.conf","--logfile","$(POD_NAME).log","--protected-mode", "no", "--bind", "$(POD_IP)", "--daemonize", "no"]
         lifecycle:
           postStart:
             exec:

--- a/kubernetes/codis-server.yaml
+++ b/kubernetes/codis-server.yaml
@@ -1,0 +1,78 @@
+apiVersion: "apps/v1beta1"
+kind: StatefulSet
+metadata:
+  name: codis-server
+spec:
+  serviceName: codis-server
+  replicas: 4
+  template:
+    metadata:
+      labels:
+        app: codis-server
+      annotations:
+        scheduler.alpha.kubernetes.io/affinity: >
+            {
+              "podAntiAffinity": {
+                "preferredDuringSchedulingIgnoredDuringExecution": [{
+                  "weight":100,
+                  "labelSelector": {
+                    "matchExpressions": [{
+                      "key": "app",
+                      "operator": "In",
+                      "values": ["codis-server"]
+                    }]
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }]
+              }
+            }
+    spec:
+      imagePullSecrets:
+      - name: your-registry
+      containers:
+      - name: codis-server
+        image: codis-image
+        imagePullPolicy: IfNotPresent
+        command: ["codis-server"]
+        args: ["$(CODIS_PATH)/config/redis.conf","--logfile","$(POD_NAME).log","--protected-mode", "no", "--save", "", "--bind", "$(POD_IP)", "--daemonize", "no"]
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "codis-admin --dashboard=codis-dashboard:18080 --reload; if [ $? != 0 ]; then exit 1; fi; \
+                        sid=`hostname |awk -F'-' '{print $3}'`;gid=$(expr $sid / ${SERVER_REPLICA} + 1); \
+                        codis-admin --dashboard=codis-dashboard:18080 --create-group --gid=${gid} 1>/dev/null 2>&1; \
+                        codis-admin --dashboard=codis-dashboard:18080 --group-add --gid=${gid} --addr=${POD_IP}:6379; 
+                        if [ $? != 0  -a ${SERVER_REPLICA} -gt 1 ]; then exit 1; fi; \
+                        codis-admin --dashboard=codis-dashboard:18080 --sync-action --create --addr=${POD_IP}:6379 1>/dev/null 2>&1 "]
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "codis-admin --dashboard=codis-dashboard:18080 --reload; if [ $? != 0 ]; then exit 1; fi; \
+                        sid=`hostname |awk -F'-' '{print $3}'`;gid=$(expr $sid / ${SERVER_REPLICA} + 1); sleep 5;\
+                        codis-admin --dashboard=codis-dashboard:18080 --group-del --gid=${gid} --addr=${POD_IP}:6379"]
+        env:
+        - name: SERVER_REPLICA
+          value: "2"
+        - name: CODIS_PATH
+          value: "/gopath/src/github.com/CodisLabs/codis"
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 6379
+          name: service-port
+        resources:
+          limits:
+            cpu: "2"
+            memory: 6Gi
+          requests:
+            cpu: "0.1"
+            memory: 0.1Gi

--- a/kubernetes/codis-service.yaml
+++ b/kubernetes/codis-service.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: codis-dashboard
+  name: codis-dashboard
+spec:
+  clusterIP: None
+  ports:
+    - port: 18080
+  selector:
+    app: codis-dashboard
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: codis-fe
+  name: codis-fe
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      nodePort: 31080
+  selector:
+    app: codis-fe
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: codis-proxy
+  name: codis-proxy
+spec:
+  ports:
+    - port: 11080
+      name: proxy
+    - port: 19000
+      name: admin
+  selector:
+    app: codis-proxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: codis-server
+  name: codis-server
+spec:
+  clusterIP: None
+  ports:
+    - port: 6379
+  selector:
+    app: codis-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: codis-ha
+  name: codis-ha
+spec:
+  clusterIP: None
+  ports:
+    - port: 12345
+  selector:
+    app: codis-ha

--- a/kubernetes/start.sh
+++ b/kubernetes/start.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+product_name="codis-test"
+#product_auth="auth"
+case "$1" in
+
+### 清理原来codis遗留数据
+cleanup)
+    kubectl delete -f .
+    # 登陆上zk 机器 执行 zkCli.sh -server {zk-addr}:2181 rmr /codis3/$product_name
+    kubectl exec -it zk-0 -- zkCli.sh -server zk-0:2181 rmr /codis3/$product_name
+    ;;
+
+### 创建新的codis集群
+buildup)
+    kubectl delete -f .
+    # 登陆上zk 机器 执行 zkCli.sh -server {zk-addr}:2181 rmr /codis3/$product_name
+    kubectl exec -it zk-0 -- zkCli.sh -server zk-0:2181 rmr /codis3/$product_name
+    kubectl create -f codis-service.yaml
+    kubectl create -f codis-dashboard.yaml
+    while [ $(kubectl get pods -l app=codis-dashboard |grep Running |wc -l) != 1 ]; do sleep 1; done;
+    kubectl create -f codis-proxy.yaml
+    kubectl create -f codis-server.yaml
+    servers=$(grep "replicas" codis-server.yaml |awk  '{print $2}')
+    while [ $(kubectl get pods -l app=codis-server |grep Running |wc -l) != $servers ]; do sleep 1; done;
+    kubectl exec -it codis-server-0 -- codis-admin  --dashboard=codis-dashboard:18080 --rebalance --confirm
+    kubectl create -f codis-ha.yaml
+    kubectl create -f codis-fe.yaml
+    sleep 60
+    kubectl exec -it codis-dashboard-0 -- redis-cli -h codis-proxy -p 19000 PING
+    if [ $? != 0 ]; then
+        echo "buildup codis cluster with problems, plz check it!!"
+    fi
+    ;;
+
+### 扩容／缩容 codis proxy
+scale-proxy)
+    kubectl scale rc codis-proxy --replicas=$2
+    ;;
+
+### 扩容／[缩容] codis server
+scale-server)
+    cur=$(kubectl get statefulset codis-server |tail -n 1 |awk '{print $3}')
+    des=$2
+    echo $cur
+    echo $des
+    if [ $cur == $des ]; then
+        echo "current server == desired server, return"
+    elif [ $cur < $des ]; then
+        kubectl scale statefulsets codis-server --replicas=$des
+        while [ $(kubectl get pods -l app=codis-server |grep Running |wc -l) != $2 ]; do sleep 1; done;
+        kubectl exec -it codis-server-0 -- codis-admin  --dashboard=codis-dashboard:18080 --rebalance --confirm
+    else
+        echo "reduce the number of codis-server, does not support, plz wait"
+        # while [ $cur > $des ]
+        # do
+        #    cur=`expr $cur - 2`
+        #    gid=$(expr $cur / 2 + 1)
+        #    kubectl exec -it codis-server-0 -- codis-admin  --dashboard=codis-dashboard:18080 --slot-action --create-some --gid-from=$gid --gid-to=1 --num-slots=1024
+        #    while [ $(kubectl exec -it codis-server-0 -- codis-admin  --dashboard=codis-dashboard:18080  --slots-status |grep "\"backend_addr_group_id\": $gid" |wc -l) != 0 ]; do echo "waiting slot migrating..."; sleep 1; done;
+        #    kubectl scale statefulsets codis-server --replicas=$cur
+        #    kubectl exec -it codis-server-0 -- codis-admin  --dashboard=codis-dashboard:18080 --remove-group --gid=$gid
+        # done
+        # kubectl scale statefulsets codis-server --replicas=$des
+        # kubectl exec -it codis-server-0 -- codis-admin  --dashboard=codis-dashboard:18080 --rebalance --confirm
+    fi
+
+    ;;    
+
+*)
+    echo "wrong argument(s)"
+    ;;
+
+esac

--- a/kubernetes/start.sh
+++ b/kubernetes/start.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [ $(kubectl get pods -l app=zk |grep Running |wc -l) == 0 ]; then
+    echo "start create zookeeper cluster"
+    kubectl create -f zookeeper/zookeeper-service.yaml
+    kubectl create -f zookeeper/zookeeper.yaml
+    while [ $(kubectl get pods -l app=zk |grep Running |wc -l) != 3 ]; do sleep 1; done;
+    echo "finish create zookeeper cluster"
+fi
+
 product_name="codis-test"
 #product_auth="auth"
 case "$1" in
@@ -7,14 +15,14 @@ case "$1" in
 ### 清理原来codis遗留数据
 cleanup)
     kubectl delete -f .
-    # 登陆上zk 机器 执行 zkCli.sh -server {zk-addr}:2181 rmr /codis3/$product_name
+    # 如果zookeeper不是在kurbernetes上，需要登陆上zk机器 执行 zkCli.sh -server {zk-addr}:2181 rmr /codis3/$product_name
     kubectl exec -it zk-0 -- zkCli.sh -server zk-0:2181 rmr /codis3/$product_name
     ;;
 
 ### 创建新的codis集群
 buildup)
     kubectl delete -f .
-    # 登陆上zk 机器 执行 zkCli.sh -server {zk-addr}:2181 rmr /codis3/$product_name
+    # 如果zookeeper不是在kurbernetes上，需要登陆上zk机器 执行 zkCli.sh -server {zk-addr}:2181 rmr /codis3/$product_name
     kubectl exec -it zk-0 -- zkCli.sh -server zk-0:2181 rmr /codis3/$product_name
     kubectl create -f codis-service.yaml
     kubectl create -f codis-dashboard.yaml

--- a/kubernetes/zookeeper/zookeeper-service.yaml
+++ b/kubernetes/zookeeper/zookeeper-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+  labels:
+    app: zookeeper
+spec:
+  ports:
+  - port: 2888
+    name: server
+  - port: 3888
+    name: leader-election
+  clusterIP: None
+  selector:
+    app: zk

--- a/kubernetes/zookeeper/zookeeper.yaml
+++ b/kubernetes/zookeeper/zookeeper.yaml
@@ -1,0 +1,148 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zk-config
+data:
+  ensemble: "zk-0;zk-1;zk-2"
+  jvm.heap: "2G"
+  tick: "2000"
+  init: "10"
+  sync: "5"
+  client.cnxns: "60"
+  snap.retain: "3"
+  purge.interval: "1"
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zk-budget
+spec:
+  selector:
+    matchLabels:
+      app: zk
+  minAvailable: 2
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: zk
+spec:
+  serviceName: zookeeper
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: zk
+      annotations:
+        pod.alpha.kubernetes.io/initialized: "true"
+        scheduler.alpha.kubernetes.io/affinity: >
+            {
+              "podAntiAffinity": {
+                "requiredDuringSchedulingRequiredDuringExecution": [{
+                  "labelSelector": {
+                    "matchExpressions": [{
+                      "key": "app",
+                      "operator": "In",
+                      "values": ["zk-headless"]
+                    }]
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }]
+              }
+            }
+    spec:
+      containers:
+      - name: k8szk
+        imagePullPolicy: IfNotPresent
+        image: gcr.io/google_samples/k8szk:v1
+        resources:
+          limits:
+            cpu: "1"
+            memory: 4Gi
+          requests:
+            memory: "0.1Gi"
+            cpu: "0.1"
+        ports:
+        - containerPort: 2181
+          name: client
+        - containerPort: 2888
+          name: server
+        - containerPort: 3888
+          name: leader-election
+        env:
+        - name : ZK_ENSEMBLE
+          valueFrom:
+            configMapKeyRef:
+              name: zk-config
+              key: ensemble
+        - name : ZK_HEAP_SIZE
+          valueFrom:
+            configMapKeyRef:
+                name: zk-config
+                key: jvm.heap
+        - name : ZK_TICK_TIME
+          valueFrom:
+            configMapKeyRef:
+                name: zk-config
+                key: tick
+        - name : ZK_INIT_LIMIT
+          valueFrom:
+            configMapKeyRef:
+                name: zk-config
+                key: init
+        - name : ZK_SYNC_LIMIT
+          valueFrom:
+            configMapKeyRef:
+                name: zk-config
+                key: tick
+        - name : ZK_MAX_CLIENT_CNXNS
+          valueFrom:
+            configMapKeyRef:
+                name: zk-config
+                key: client.cnxns
+        - name: ZK_SNAP_RETAIN_COUNT
+          valueFrom:
+            configMapKeyRef:
+                name: zk-config
+                key: snap.retain
+        - name: ZK_PURGE_INTERVAL
+          valueFrom:
+            configMapKeyRef:
+                name: zk-config
+                key: purge.interval
+        - name: ZK_CLIENT_PORT
+          value: "2181"
+        - name: ZK_SERVER_PORT
+          value: "2888"
+        - name: ZK_ELECTION_PORT
+          value: "3888"
+        command:
+        - sh
+        - -c
+        - zkGenConfig.sh && zkServer.sh start-foreground
+        readinessProbe:
+          exec:
+            command:
+            - "zkOk.sh"
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        livenessProbe:
+          exec:
+            command:
+            - "zkOk.sh"
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+#        volumeMounts:
+#        - name: datadir
+#          mountPath: /var/lib/zookeeper
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+#  volumeClaimTemplates:
+#  - metadata:
+#      name: datadir
+#    spec:
+#      accessModes: [ "ReadWriteOnce" ]
+#      resources:
+#        requests:
+#          storage: 5Gi

--- a/pkg/utils/redis/client.go
+++ b/pkg/utils/redis/client.go
@@ -101,6 +101,15 @@ func (c *Client) Select(database int) error {
 	return nil
 }
 
+func (c *Client) Shutdown() error {
+	_, err := c.Do("SHUTDOWN")
+	if err != nil {
+		c.Close()
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 func (c *Client) Info() (map[string]string, error) {
 	text, err := redigo.String(c.Do("INFO"))
 	if err != nil {


### PR DESCRIPTION
实现及操作整理的一篇文章见http://www.jianshu.com/p/a821f56d5e54
1. 一键部署，后面除了扩容（一键扩容），基本不需要人为参与
2. codis ha选择了之前使用，但现在已经去掉的codis-ha，并做了些改动。
3. 在dashboard和proxy命令行参数可以传递product name和auth，以方便支持一个环境不同的product，以及部署多套codis。
4. 经过多次测试验证，以及一些极端情况，如物理机当机的验证。当前已在生产环境运行一段时间，运行良好。