### PR TITLE
Add redis-sentinel to Codis bin dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ codis-server:
 	@cp -f extern/redis-3.2.8/src/redis-server  bin/codis-server
 	@cp -f extern/redis-3.2.8/src/redis-benchmark bin/
 	@cp -f extern/redis-3.2.8/src/redis-cli bin/
+	@cp -f extern/redis-3.2.8/src/redis-sentinel bin/
 	@cp -f extern/redis-3.2.8/redis.conf config/
 	@sed -e "s/^sentinel/# sentinel/g" extern/redis-3.2.8/sentinel.conf > config/sentinel.conf
 


### PR DESCRIPTION
在ansible中启动哨兵使用的是redis-sentinel
[https://github.com/anywhy/codis/blob/release3.2/ansible/roles/redis-sentinel/templates/redis-sentinel-admin.sh#L11](https://github.com/anywhy/codis/blob/release3.2/ansible/roles/redis-sentinel/templates/redis-sentinel-admin.sh#L11)
```
REDIS_SENTINEL_BIN=$CODIS_BIN_DIR/redis-sentinel
REDIS_SENTINEL_PID_FILE={{ redis_sentinel_workdir }}/sentinel_{{ redis_sentinel_port }}.pid
```
在bin目录中增加了redis-sentinel