### PR TITLE
skip the empty \r\n during redis-cli --pipe

### DIFF
--- a/pkg/proxy/redis/decoder.go
+++ b/pkg/proxy/redis/decoder.go
@@ -211,6 +211,9 @@ func (d *Decoder) decodeSingleLineMultiBulk() ([]*Resp, error) {
 	if err != nil {
 		return nil, err
 	}
+	if string(b) == "" {
+		return nil, nil
+	}
 	multi := make([]*Resp, 0, 8)
 	for l, r := 0, 0; r <= len(b); r++ {
 		if r == len(b) || b[r] == ' ' {

--- a/pkg/proxy/redis/decoder.go
+++ b/pkg/proxy/redis/decoder.go
@@ -211,7 +211,7 @@ func (d *Decoder) decodeSingleLineMultiBulk() ([]*Resp, error) {
 	if err != nil {
 		return nil, err
 	}
-	if string(b) == "" {
+	if len(b) == 0 {
 		return nil, nil
 	}
 	multi := make([]*Resp, 0, 8)

--- a/pkg/proxy/session.go
+++ b/pkg/proxy/session.go
@@ -164,7 +164,7 @@ func (s *Session) loopReader(tasks *RequestChan, d *Router) (err error) {
 		if err != nil {
 			return err
 		}
-		if multi == nil {
+		if len(multi) == 0 {
 			continue
 		}
 		s.incrOpTotal()

--- a/pkg/proxy/session.go
+++ b/pkg/proxy/session.go
@@ -164,6 +164,9 @@ func (s *Session) loopReader(tasks *RequestChan, d *Router) (err error) {
 		if err != nil {
 			return err
 		}
+		if multi == nil {
+			continue
+		}
 		s.incrOpTotal()
 
 		if tasks.Buffered() > maxPipelineLen {


### PR DESCRIPTION
emmm....
when using redis-cli --pipe, it will send data via pipeline first, then an empty "\r\n", then the final ECHO command to ensure all jobs are done.

codis-proxy did not process the empty \r\n correctly(by simply skipping it) but throw an error instead, causing the redis-cli --pipe hangs till timeout.