### PR TITLE
reuse proxy.Request and redis.Resp in proxy

### DIFF
--- a/pkg/proxy/backend.go
+++ b/pkg/proxy/backend.go
@@ -301,6 +301,7 @@ func (bc *BackendConn) loopReader(tasks <-chan *Request, c *redis.Conn, round in
 				}
 			}
 		}
+		r.respForRelease = resp
 		bc.setResponse(r, resp, nil)
 	}
 	return nil

--- a/pkg/proxy/redis/decoder_test.go
+++ b/pkg/proxy/redis/decoder_test.go
@@ -53,23 +53,6 @@ func TestDecodeSimpleRequest1(t *testing.T) {
 }
 
 func TestDecodeSimpleRequest2(t *testing.T) {
-	test := []string{
-		"hello world\r\n",
-		"hello world    \r\n",
-		"    hello world    \r\n",
-		"    hello     world\r\n",
-		"    hello     world    \r\n",
-	}
-	for _, s := range test {
-		a, err := DecodeMultiBulkFromBytes([]byte(s))
-		assert.MustNoError(err)
-		assert.Must(len(a) == 2)
-		assert.Must(bytes.Equal(a[0].Value, []byte("hello")))
-		assert.Must(bytes.Equal(a[1].Value, []byte("world")))
-	}
-}
-
-func TestDecodeSimpleRequest3(t *testing.T) {
 	test := []string{"\r", "\n", " \n"}
 	for _, s := range test {
 		_, err := DecodeFromBytes([]byte(s))
@@ -139,9 +122,9 @@ func newBenchmarkDecoder(n int) *Decoder {
 func benchmarkDecode(b *testing.B, n int) {
 	d := newBenchmarkDecoder(n)
 	for i := 0; i < b.N; i++ {
-		multi, err := d.DecodeMultiBulk()
+		resp, err := d.Decode()
 		assert.MustNoError(err)
-		assert.Must(len(multi) == 1 && len(multi[0].Value) == n)
+		assert.Must(len(resp.Array) == 1 && len(resp.Array[0].Value) == n)
 	}
 }
 


### PR DESCRIPTION
proxy 处理请求的过程中经常需要分配 `proxy.Request` 和 `redis.Resp` 两种对象。这个 PR 通过 `sync.Pool` 进行了复用，应当可以降低GC压力。

`proxy.Request` and `redis.Resp` is allocated most often in request processing. This PR try to reuse these objects using `sync.Pool` which should reduce the GC pressure.