### PR TITLE
Fix redis lua library vulnerabilities (CVE-2024-31449, CVE-2025-49844)

### DIFF
--- a/extern/redis-3.2.11/deps/lua/src/lparser.c
+++ b/extern/redis-3.2.11/deps/lua/src/lparser.c
@@ -384,13 +384,17 @@ Proto *luaY_parser (lua_State *L, ZIO *z, Mbuffer *buff, const char *name) {
   struct LexState lexstate;
   struct FuncState funcstate;
   lexstate.buff = buff;
-  luaX_setinput(L, &lexstate, z, luaS_new(L, name));
+  TString *tname = luaS_new(L, name);
+  setsvalue2s(L, L->top, tname);
+  incr_top(L);
+  luaX_setinput(L, &lexstate, z, tname);
   open_func(&lexstate, &funcstate);
   funcstate.f->is_vararg = VARARG_ISVARARG;  /* main func. is always vararg */
   luaX_next(&lexstate);  /* read first token */
   chunk(&lexstate);
   check(&lexstate, TK_EOS);
   close_func(&lexstate);
+  --L->top;
   lua_assert(funcstate.prev == NULL);
   lua_assert(funcstate.f->nups == 0);
   lua_assert(lexstate.fs == NULL);

--- a/extern/redis-3.2.11/deps/lua/src/lua_bit.c
+++ b/extern/redis-3.2.11/deps/lua/src/lua_bit.c
@@ -131,6 +131,7 @@ static int bit_tohex(lua_State *L)
   const char *hexdigits = "0123456789abcdef";
   char buf[8];
   int i;
+  if (n == INT32_MIN) n = INT32_MIN+1;
   if (n < 0) { n = -n; hexdigits = "0123456789ABCDEF"; }
   if (n > 8) n = 8;
   for (i = (int)n; --i >= 0; ) { buf[i] = hexdigits[b & 15]; b >>= 4; }

--- a/extern/redis-3.2.11/tests/unit/scripting.tcl
+++ b/extern/redis-3.2.11/tests/unit/scripting.tcl
@@ -337,6 +337,12 @@ start_server {tags {"scripting"}} {
         set e
     } {*ERR*attempted to create global*}
 
+    test {lua bit.tohex bug} {
+        set res [run_script {return bit.tohex(65535, -2147483648)} 0]
+        r ping
+        set res
+    } {0000FFFF}
+
     test {Test an example script DECR_IF_GT} {
         set decr_if_gt {
             local current


### PR DESCRIPTION
### CVE-2024-31449
Affected component/file: `lua_bit.c`
CVE-2024-31449 was found in Redis, and the same behavior is reproduced in Dragonfly.
A Lua stack overflow causes a crash.
According to the [Redis security advisory](https://github.com/redis/redis/security/advisories/GHSA-whxg-wx83-85p5), this vulnerability can lead to RCE attacks.

### CVE-2025-29844
Affected component/file: `lparser.c`
Redis versions 6.2.6 and below are vulnerable to remote code execution via a specially crafted Lua script that manipulates the garbage collector to trigger use-after-free.
Fixed in version 8.2.2. Workaround: Use ACL to restrict EVAL and EVALSHA commands.
According to the [Redis security advisory](https://github.com/redis/redis/security/advisories/GHSA-4789-qfc9-5f9q), this vulnerability can lead use-after-free and potentially lead to remote code execution.